### PR TITLE
Button model added

### DIFF
--- a/defaults/Rebass/Button.json
+++ b/defaults/Rebass/Button.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "Button",
+    "variant": "default",
+    "children": [
+      {
+        "type": "span",
+        "variant": "default",
+        "props": {},
+        "children": [],
+        "text": "Text"
+      }
+    ],
+    "namespace": "Rebass",
+    "props": {}
+  },
+  {
+    "type": "Button",
+    "namespace": "Rebass",
+    "variant": "Rounded",
+    "props": {
+      "rounded": true
+    },
+    "children": [
+      {
+        "type": "span",
+        "variant": "default",
+        "props": {},
+        "children": [],
+        "text": "Button"
+      }
+    ]
+  }
+]

--- a/docs/Rebass/Arrow.md
+++ b/docs/Rebass/Arrow.md
@@ -1,0 +1,7 @@
+##### This is a Rebass/Arrow React component documentation template
+
+Documentation will be displayed in the component options dialog which you can open in Structor workspace.
+
+So, if there is some notes worth to remember, like descriptions of available props in component, place them here.
+
+**Please find file to edit in: `.structor/docs/components`**

--- a/modules/Rebass/index.js
+++ b/modules/Rebass/index.js
@@ -1,3 +1,6 @@
+
 import {Arrow,Avatar,Badge,Banner,Block,Blockquote,Breadcrumbs,Button,ButtonCircle,ButtonOutline,Card,CardImage,Checkbox,Close,Container,Divider,Donut,DotIndicator,Drawer,Dropdown,DropdownMenu,Embed,Fixed,Footer,Heading,HeadingLink,InlineForm,Input,Label,LinkBlock,Media,Menu,Message,NavItem,Overlay,PageHeader,Panel,PanelFooter,PanelHeader,Pre,Progress,Radio,Rating,Section,SectionHeader,Select,SequenceMap,SequenceMapStep,Slider,Space,Stat,Switch,Table,Text,Textarea,Toolbar,Tooltip} from 'rebass';
 
 export {Arrow,Avatar,Badge,Banner,Block,Blockquote,Breadcrumbs,Button,ButtonCircle,ButtonOutline,Card,CardImage,Checkbox,Close,Container,Divider,Donut,DotIndicator,Drawer,Dropdown,DropdownMenu,Embed,Fixed,Footer,Heading,HeadingLink,InlineForm,Input,Label,LinkBlock,Media,Menu,Message,NavItem,Overlay,PageHeader,Panel,PanelFooter,PanelHeader,Pre,Progress,Radio,Rating,Section,SectionHeader,Select,SequenceMap,SequenceMapStep,Slider,Space,Stat,Switch,Table,Text,Textarea,Toolbar,Tooltip};
+
+


### PR DESCRIPTION
As no models were included - Rebass components are unavailable in structor. As an example, I have added the model `Button.json` for `<Button />`. Now, all Rebass components are available for users who have installed this package.

To make this package more useful for users - different models for components should be created.